### PR TITLE
Fix to treat nil text body in pull_request_review hook

### DIFF
--- a/app/models/tokite/hook_event/issue_comment.rb
+++ b/app/models/tokite/hook_event/issue_comment.rb
@@ -5,7 +5,7 @@ module Tokite
         {
           event: "issue_comment",
           repo: hook_params[:repository][:full_name],
-          body: hook_params[:comment][:body] || "",
+          body: hook_params[:comment][:body],
           user: hook_params[:comment][:user][:login],
         }
       end
@@ -20,8 +20,8 @@ module Tokite
   
       def slack_attachment
         {
-          fallback: hook_params[:comment][:body] || "",
-          text: hook_params[:comment][:body] || "",
+          fallback: hook_params[:comment][:body],
+          text: hook_params[:comment][:body],
           color: "good",
         }
       end

--- a/app/models/tokite/hook_event/pull_request_review.rb
+++ b/app/models/tokite/hook_event/pull_request_review.rb
@@ -12,10 +12,13 @@ module Tokite
       end
 
       def notify?
-        return false unless hook_params[:action] == "submitted"
-        if hook_params[:review][:state] == "commented"
-          return false unless hook_params[:review][:body].nil?
-        true
+        if hook_params[:action] != "submitted"
+          false
+        elsif hook_params[:review][:state] == "commented"
+          hook_params[:review][:body] != nil
+        else
+          true
+        end
       end
 
       def slack_text

--- a/app/models/tokite/hook_event/pull_request_review.rb
+++ b/app/models/tokite/hook_event/pull_request_review.rb
@@ -5,7 +5,7 @@ module Tokite
         {
           event: "pull_request_review",
           repo: hook_params[:repository][:full_name],
-          body: hook_params[:review][:body],
+          body: hook_params[:review][:body] || "",
           user: hook_params[:review][:user][:login],
           review_state: hook_params[:review][:state],
         }
@@ -14,7 +14,7 @@ module Tokite
       def notify?
         return false unless hook_params[:action] == "submitted"
         if hook_params[:review][:state] == "commented"
-          hook_params[:review][:body]
+          hook_params[:review][:body] || ""
         else
           true
         end
@@ -35,7 +35,6 @@ module Tokite
       end
 
       def slack_attachment
-        return unless hook_params[:review][:body]
         case hook_params[:review][:state]
           when "commented"
           when "approved"
@@ -44,8 +43,8 @@ module Tokite
             color = "warning"
         end
         {
-          fallback: hook_params[:review][:body],
-          text: hook_params[:review][:body],
+          fallback: hook_params[:review][:body] || "",
+          text: hook_params[:review][:body] || "",
           color: color,
         }
       end

--- a/app/models/tokite/hook_event/pull_request_review.rb
+++ b/app/models/tokite/hook_event/pull_request_review.rb
@@ -12,13 +12,10 @@ module Tokite
       end
 
       def notify?
-        if not hook_params[:action] == "submitted" 
-          false
-        elsif hook_params[:review][:state] == "commented"
-          not hook_params[:review][:body].nil?
-        else
-          true
-        end
+        return false unless hook_params[:action] == "submitted"
+        if hook_params[:review][:state] == "commented"
+          return false unless hook_params[:review][:body].nil?
+        true
       end
 
       def slack_text

--- a/app/models/tokite/hook_event/pull_request_review.rb
+++ b/app/models/tokite/hook_event/pull_request_review.rb
@@ -12,9 +12,10 @@ module Tokite
       end
 
       def notify?
-        return false unless hook_params[:action] == "submitted"
-        if hook_params[:review][:state] == "commented"
-          hook_params[:review][:body] || ""
+        if not hook_params[:action] == "submitted" 
+          false
+        elsif hook_params[:review][:state] == "commented"
+          not hook_params[:review][:body].nil?
         else
           true
         end

--- a/app/models/tokite/hook_event/pull_request_review_comment.rb
+++ b/app/models/tokite/hook_event/pull_request_review_comment.rb
@@ -5,7 +5,7 @@ module Tokite
         {
           event: "pull_request_review_comment",
           repo: hook_params[:repository][:full_name],
-          body: hook_params[:comment][:body] || "",
+          body: hook_params[:comment][:body],
           user: hook_params[:comment][:user][:login],
         }
       end
@@ -26,7 +26,7 @@ module Tokite
         footer_text = "Comment by #{user} on line #{line} of #{path}"
         {
           fallback: "#{hook_params[:comment][:body]}\n#{footer_text}",
-          text: hook_params[:comment][:body] || "",
+          text: hook_params[:comment][:body],
           footer: "<#{footer_url}|#{footer_text}>"
         }
       end

--- a/spec/requests/hooks_spec.rb
+++ b/spec/requests/hooks_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe "Hook", type: :request do
 
         it "fire hook" do
           expect_any_instance_of(Tokite::Hook).to receive(:fire!).and_call_original
-          expect_any_instance_of(Tokite::NotifyGithubHookEventJob).to receive(:perform)
+          expect_any_instance_of(Tokite::NotifyGithubHookEventJob).not_to receive(:perform)
           post hooks_path, params: params, headers: headers
         end
       end

--- a/spec/requests/hooks_spec.rb
+++ b/spec/requests/hooks_spec.rb
@@ -68,19 +68,6 @@ RSpec.describe "Hook", type: :request do
         expect_any_instance_of(Tokite::NotifyGithubHookEventJob).to receive(:perform)
         post hooks_path, params: params, headers: headers
       end
-
-      context "without body comment" do
-        let(:query) { %(event:issue_comment user:hogelog) }
-        before do 
-          params["comment"].delete("body")
-        end
-
-        it "fire hook" do
-          expect_any_instance_of(Tokite::Hook).to receive(:fire!).and_call_original
-          expect_any_instance_of(Tokite::NotifyGithubHookEventJob).to receive(:perform)
-          post hooks_path, params: params, headers: headers
-        end
-      end
     end
 
     context "with pull_request_review" do
@@ -115,19 +102,6 @@ RSpec.describe "Hook", type: :request do
         expect_any_instance_of(Tokite::Hook).to receive(:fire!).and_call_original
         expect_any_instance_of(Tokite::NotifyGithubHookEventJob).to receive(:perform)
         post hooks_path, params: params, headers: headers
-      end
-
-      context "without body comment" do
-        let(:query) { %(event:pull_request_review_comment user:hogelog) }
-        before do 
-          params["comment"].delete("body")
-        end
-
-        it "fire hook" do
-          expect_any_instance_of(Tokite::Hook).to receive(:fire!).and_call_original
-          expect_any_instance_of(Tokite::NotifyGithubHookEventJob).to receive(:perform)
-          post hooks_path, params: params, headers: headers
-        end
       end
     end
 

--- a/spec/requests/hooks_spec.rb
+++ b/spec/requests/hooks_spec.rb
@@ -66,6 +66,19 @@ RSpec.describe "Hook", type: :request do
         expect_any_instance_of(Tokite::NotifyGithubHookEventJob).to receive(:perform)
         post hooks_path, params: params, headers: headers
       end
+
+      context "without body comment" do 
+        let(:query) { %(event:pull_request_review user:hogelog) }
+        before do 
+          params["review"].delete("body")
+        end
+
+        it "fire hook" do
+          expect_any_instance_of(Tokite::Hook).to receive(:fire!).and_call_original
+          expect_any_instance_of(Tokite::NotifyGithubHookEventJob).to receive(:perform)
+          post hooks_path, params: params, headers: headers
+        end
+      end
     end
 
     context "with pull_request_review_comment" do


### PR DESCRIPTION
Fix bug occurring when `hook_params[:review][:body]` is `nil` in `review` event hooking.
