### PR TITLE
Add input form for editting display name in Slack channel

### DIFF
--- a/app/controllers/tokite/rules_controller.rb
+++ b/app/controllers/tokite/rules_controller.rb
@@ -46,7 +46,7 @@ module Tokite
     private
 
     def rule_params
-      params.require(:rule).permit(:user_id, :name, :query, :channel, :icon_emoji, :additional_text)
+      params.require(:rule).permit(:user_id, :name, :query, :channel, :icon_emoji, :additional_text, :display_name)
     end
   end
 end

--- a/app/models/tokite/hook.rb
+++ b/app/models/tokite/hook.rb
@@ -32,7 +32,7 @@ module Tokite
         if payloads.none? {|payload| payload[:channel] == rule.channel && payload[:emoji] == emoji && payload[:additional_text] == additional_text }
           payloads << {
             channel: rule.channel,
-            username: (rule.display_name == "") ? "tokite" : rule.display_name,
+            username: rule.display_name.presence || "tokite",
             text: event.slack_text,
             emoji: emoji,
             additional_text: additional_text,
@@ -48,13 +48,15 @@ module Tokite
           attachments: payload[:attachments],
           username: payload[:username]
         )
-        notify!(
-          channel: payload[:channel],
-          text: payload[:additional_text],
-          icon_emoji: payload[:emoji],
-          parse: "full",
-          username: payload[:username]
-        ) if payload[:additional_text].present?
+        if payload[:additional_text].present?
+          notify!(
+            channel: payload[:channel],
+            text: payload[:additional_text],
+            icon_emoji: payload[:emoji],
+            parse: "full",
+            username: payload[:username]
+          ) 
+        end
       end
     end
 

--- a/app/models/tokite/hook.rb
+++ b/app/models/tokite/hook.rb
@@ -32,6 +32,7 @@ module Tokite
         if payloads.none? {|payload| payload[:channel] == rule.channel && payload[:emoji] == emoji && payload[:additional_text] == additional_text }
           payloads << {
             channel: rule.channel,
+            username: (rule.display_name == "") ? "tokite" : rule.display_name,
             text: event.slack_text,
             emoji: emoji,
             additional_text: additional_text,
@@ -40,8 +41,20 @@ module Tokite
         end
       end
       payloads.each do |payload|
-        notify!(channel: payload[:channel], text: payload[:text], icon_emoji: payload[:emoji], attachments: payload[:attachments])
-        notify!(channel: payload[:channel], text: payload[:additional_text], icon_emoji: payload[:emoji], parse: "full") if payload[:additional_text].present?
+        notify!(
+          channel: payload[:channel],
+          text: payload[:text],
+          icon_emoji: payload[:emoji],
+          attachments: payload[:attachments],
+          username: payload[:username]
+        )
+        notify!(
+          channel: payload[:channel],
+          text: payload[:additional_text],
+          icon_emoji: payload[:emoji],
+          parse: "full",
+          username: payload[:username]
+        ) if payload[:additional_text].present?
       end
     end
 

--- a/app/views/tokite/rules/_form.html.haml
+++ b/app/views/tokite/rules/_form.html.haml
@@ -4,6 +4,7 @@
   = form_text_field f, :channel, size: 40, class: "input"
   = form_text_field f, :icon_emoji, size: 40, class: "input"
   = form_text_field f, :additional_text, size: 40, class: "input"
+  = form_text_field f, :display_name, size: 40, class: "input"
   .field.columns
     .column.is-8= f.submit "Update", class: "button is-primary"
     - if @rule.persisted?

--- a/schema/tokite_rules.schema
+++ b/schema/tokite_rules.schema
@@ -5,9 +5,9 @@ create_table "tokite_rules", force: :cascade do |t|
   t.string   "channel",         limit: 100,  null: false
   t.string   "icon_emoji",      limit: 20,   null: false, default: ""
   t.string   "additional_text", limit: 200,  null: false, default: ""
-  t.string   "display_name",    limit: 60,   null: false, default: ""
   t.datetime "created_at",                   null: false
   t.datetime "updated_at",                   null: false
+  t.string   "display_name",    limit: 60,   null: false, default: ""
 end
 
 add_index "tokite_rules", ["user_id", "name"], name: "tokite_rule_uniq_name", unique: true, using: :btree

--- a/schema/tokite_rules.schema
+++ b/schema/tokite_rules.schema
@@ -5,6 +5,7 @@ create_table "tokite_rules", force: :cascade do |t|
   t.string   "channel",         limit: 100,  null: false
   t.string   "icon_emoji",      limit: 20,   null: false, default: ""
   t.string   "additional_text", limit: 200,  null: false, default: ""
+  t.string   "display_name",    limit: 60,   null: false, default: ""
   t.datetime "created_at",                   null: false
   t.datetime "updated_at",                   null: false
 end

--- a/spec/dummy/schema/tokite/tokite_rules.schema
+++ b/spec/dummy/schema/tokite/tokite_rules.schema
@@ -5,9 +5,9 @@ create_table "tokite_rules", force: :cascade do |t|
   t.string   "channel",         limit: 100,  null: false
   t.string   "icon_emoji",      limit: 20,   null: false, default: ""
   t.string   "additional_text", limit: 200,  null: false, default: ""
-  t.string   "display_name",    limit: 60,   null: false, default: ""
   t.datetime "created_at",                   null: false
   t.datetime "updated_at",                   null: false
+  t.string   "display_name",    limit: 60,   null: false, default: ""
 end
 
 add_index "tokite_rules", ["user_id", "name"], name: "tokite_rule_uniq_name", unique: true, using: :btree

--- a/spec/dummy/schema/tokite/tokite_rules.schema
+++ b/spec/dummy/schema/tokite/tokite_rules.schema
@@ -5,6 +5,7 @@ create_table "tokite_rules", force: :cascade do |t|
   t.string   "channel",         limit: 100,  null: false
   t.string   "icon_emoji",      limit: 20,   null: false, default: ""
   t.string   "additional_text", limit: 200,  null: false, default: ""
+  t.string   "display_name",    limit: 60,   null: false, default: ""
   t.datetime "created_at",                   null: false
   t.datetime "updated_at",                   null: false
 end

--- a/spec/dummy/schema/tokite_rules.schema
+++ b/spec/dummy/schema/tokite_rules.schema
@@ -5,9 +5,9 @@ create_table "tokite_rules", force: :cascade do |t|
   t.string   "channel",         limit: 100,  null: false
   t.string   "icon_emoji",      limit: 20,   null: false, default: ""
   t.string   "additional_text", limit: 200,  null: false, default: ""
-  t.string   "display_name",    limit: 60,   null: false, default: ""
   t.datetime "created_at",                   null: false
   t.datetime "updated_at",                   null: false
+  t.string   "display_name",    limit: 60,   null: false, default: ""
 end
 
 add_index "tokite_rules", ["user_id", "name"], name: "tokite_rule_uniq_name", unique: true, using: :btree

--- a/spec/dummy/schema/tokite_rules.schema
+++ b/spec/dummy/schema/tokite_rules.schema
@@ -5,6 +5,7 @@ create_table "tokite_rules", force: :cascade do |t|
   t.string   "channel",         limit: 100,  null: false
   t.string   "icon_emoji",      limit: 20,   null: false, default: ""
   t.string   "additional_text", limit: 200,  null: false, default: ""
+  t.string   "display_name",    limit: 60,   null: false, default: ""
   t.datetime "created_at",                   null: false
   t.datetime "updated_at",                   null: false
 end

--- a/spec/models/tokite/hook_spec.rb
+++ b/spec/models/tokite/hook_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Tokite::Hook, type: :model do
   xdescribe "fire!" do
     context "for debug" do
       before do
-        FactoryBot.create(:rule, query: "/./", channel: "#test-private", additional_text: "@hogelog Hi!")
+        FactoryBot.create(:rule, query: "/./", channel: "#test-private", additional_text: "@hogelog Hi!", display_name: "tokite-spec")
       end
       let(:params) {
         JSON.parse(payload_json("#{event}.json")).with_indifferent_access


### PR DESCRIPTION
Ref. #35 

Enable to edit display name for each slack notifications.
Please review it.