### PR TITLE
Use issue labels info also for issue_comment event

### DIFF
--- a/app/models/tokite/hook_event/issue_comment.rb
+++ b/app/models/tokite/hook_event/issue_comment.rb
@@ -7,17 +7,18 @@ module Tokite
           repo: hook_params[:repository][:full_name],
           body: hook_params[:comment][:body],
           user: hook_params[:comment][:user][:login],
+          label: hook_params[:issue][:labels].map { |label| label[:name] },
         }
       end
-  
+
       def notify?
         %w(created).include?(hook_params[:action])
       end
-  
+
       def slack_text
         "[#{hook_params[:repository][:full_name]}] New comment by #{hook_params[:comment][:user][:login]} on issue <#{hook_params[:comment][:html_url]}|##{hook_params[:issue][:number]}: #{hook_params[:issue][:title]}>"
       end
-  
+
       def slack_attachment
         {
           fallback: hook_params[:comment][:body],


### PR DESCRIPTION
## Problem

Tokite never notify events when a query includes `label:xxx` with `event:/issue_comment/`.

## Solution

Make `IssueComment` events respect `label` query field like `Issue` events.

Please review it. 🙏 