### PR TITLE
Upgrade bulma to 0.9.4

### DIFF
--- a/app/assets/stylesheets/tokite/application.scss
+++ b/app/assets/stylesheets/tokite/application.scss
@@ -1,6 +1,6 @@
 @import "bulma/sass/utilities/initial-variables";
 
-// Bootstrap like colors
+// Bootstrap-like colors
 $white:  #fff;
 $black:  #000;
 $red:    #d9534f;
@@ -21,7 +21,3 @@ $dark: $grey-darker;
 $text: $grey-dark;
 
 @import "bulma/bulma";
-
-.vspace-40 {
-  margin: 40px 0;
-}

--- a/app/helpers/tokite/application_helper.rb
+++ b/app/helpers/tokite/application_helper.rb
@@ -2,9 +2,9 @@ module Tokite
   module ApplicationHelper
     def nav_list_item(name, path, controllers)
       if controllers.include?(params[:controller])
-        link_to(name, path, class: "nav-item is-tab is-active")
+        link_to(name, path, class: "navbar-item is-tab is-active")
       else
-        link_to(name, path, class: "nav-item is-tab")
+        link_to(name, path, class: "navbar-item is-tab")
       end
     end
 

--- a/app/views/layouts/tokite/application.html.haml
+++ b/app/views/layouts/tokite/application.html.haml
@@ -9,15 +9,15 @@
 
   %body
     - if current_user
-      %nav.nav.has-shadow
-        .container
-          .nav-left
+      %nav.navbar.has-shadow
+        .navbar-menu.is-active
+          .navbar-start
             = nav_list_item "Top", root_path, ["top"]
             = nav_list_item "Users", users_path, ["users"]
             = nav_list_item "Rules", rules_path, ["rules"]
             = nav_list_item "Repositories", repositories_path, ["repositories"]
-          .nav-right
-            %span.nav-item.is-tab= current_user.name_with_provider
+          .navbar-end
+            %span.navbar-item= current_user.name_with_provider
 
     %section.section
       - if flash[:error]

--- a/app/views/tokite/repositories/index.html.haml
+++ b/app/views/tokite/repositories/index.html.haml
@@ -1,11 +1,11 @@
 - if current_user_token
   = link_to "Watch new repositories", new_repository_path, class: "button is-primary"
 
-.vspace-40
+.my-6
 
 %h1.title Watching repositories
 
-%table.table.is-bordered
+%table.table.is-bordered.is-hoverable
   - @repositories.each do |repo|
     %tr
       %td= link_to repo.name, repo.url

--- a/app/views/tokite/repositories/new.html.haml
+++ b/app/views/tokite/repositories/new.html.haml
@@ -11,7 +11,7 @@
                 %span.tag.is-danger{style: "height: 1.5em"} private
               = link_to "@", repo.url
 
-    .vspace-40
+    .my-6
 
     .field
       .control

--- a/app/views/tokite/rules/_form.html.haml
+++ b/app/views/tokite/rules/_form.html.haml
@@ -11,7 +11,7 @@
       .column.is-2= link_to "Transfer", new_rule_transfers_path(@rule), class: "button is-primary"
       .column.is-2= link_to "Delete", rule_path(@rule), method: :delete, data: { confirm: %(Delete "#{@rule.name}"?) }, class: "button is-danger"
 
-.message.vspace-40
+.message.my-6
   .message-header
     Query description
   .message-body

--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
   "name": "tokite",
   "private": true,
   "dependencies": {
-    "bulma": "^0.4.2"
+    "bulma": "^0.9.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,7 @@
 # yarn lockfile v1
 
 
-bulma@^0.4.2:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/bulma/-/bulma-0.4.2.tgz#3be8c832cf6658bfc421ecb41f6dc5a8a0c7c0e5"
+bulma@^0.9.4:
+  version "0.9.4"
+  resolved "https://registry.yarnpkg.com/bulma/-/bulma-0.9.4.tgz#0ca8aeb1847a34264768dba26a064c8be72674a1"
+  integrity sha512-86FlT5+1GrsgKbPLRRY7cGDg8fsJiP/jzTqXXVqiUZZ2aZT8uemEOHlU1CDU+TxklPEZ11HZNNWclRBBecP4CQ==


### PR DESCRIPTION
- Since bulma 0.6.0 removes nav.sass, nav is replaced by navbar.
- bulma 0.9.0 introduces spacing helpers.
- Page design is slightly modificated in the same manner with bulma's changes.

## Diff Images

| Before | After |
| -- | -- |
|<img width="1512" alt="screenshot" src="https://github.com/cookpad/tokite/assets/4374702/94fe8a36-e708-41cc-912f-5f9eef444668">|<img width="1512" alt="screenshot" src="https://github.com/cookpad/tokite/assets/4374702/a9da23a7-8462-40e9-bdc1-11a9e41a867f">|
|<img width="1512" alt="screenshot" src="https://github.com/cookpad/tokite/assets/4374702/3464ae3a-d60b-467b-b2a7-ece0078e1202">|<img width="1512" alt="screenshot" src="https://github.com/cookpad/tokite/assets/4374702/9c099f11-54fb-4121-a0f9-8dc4156d1900">|
