### PR TITLE
Upgrade omniauth-github to v2

### DIFF
--- a/app/views/tokite/sessions/new.html.haml
+++ b/app/views/tokite/sessions/new.html.haml
@@ -1,1 +1,2 @@
-= link_to "Login with GitHub", "/auth/github"
+= form_with url: "/auth/github", method: :post do |form|
+  = form.submit "Login with GitHub", class: "button"

--- a/tokite.gemspec
+++ b/tokite.gemspec
@@ -21,7 +21,8 @@ Gem::Specification.new do |s|
   s.add_dependency 'sass-rails', '~> 6.0'
   s.add_dependency "haml"
   s.add_dependency "haml-rails"
-  s.add_dependency "omniauth-github"
+  s.add_dependency "omniauth-github", ">= 2.0.0"
+  s.add_dependency "omniauth-rails_csrf_protection"
   s.add_dependency "octokit"
   s.add_dependency "slack-notifier"
   s.add_dependency "ridgepole"


### PR DESCRIPTION
Due to https://github.com/omniauth/omniauth/wiki/Upgrading-to-2.0, login links must be replaced to buttons.

Note for users of tokite gem: Please add omniauth-rails_csrf_protection gem to your Gemfile. Without this, `OmniAuth::AuthenticityError` may happen.